### PR TITLE
Fixes bug of misplaced inf markers when axis scale is logarithmic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 
 install:
   - conda update --yes conda
+  - conda config --append channels conda-forge
   - conda install --yes python=$CONDA atlas numpy scipy matplotlib pip pymongo pyflakes pytest setuptools
   - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_install:
 
 install:
   - conda update --yes conda
-  - conda config --append channels conda-forge
-  - conda install --yes python=$CONDA atlas numpy scipy matplotlib pip pymongo pyflakes pytest setuptools
+  - conda install --yes -c anaconda atlas
+  - conda install --yes python=$CONDA numpy scipy matplotlib pip pymongo pyflakes pytest setuptools
   - pip install .
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-pyDistEval
+pyDistEval 
 =======================
 
 [![Build Status](https://travis-ci.org/tudo-astroparticlephysics/pydisteval.svg?branch=master)](https://travis-ci.org/tudo-astroparticlephysics/pydisteval)

--- a/disteval/visualization/comparison_plotter/functions/plot_funcs.py
+++ b/disteval/visualization/comparison_plotter/functions/plot_funcs.py
@@ -36,7 +36,7 @@ def plot_inf_marker(fig,
                     markerfacecolor='none',
                     bot=True,
                     alpha=1.,
-                    rel_marker_size=0.009):
+                    rel_marker_size=0.007):
 
     # compute marker size
     pixel_width, pixel_height = fig.canvas.get_width_height()

--- a/disteval/visualization/comparison_plotter/functions/plot_funcs.py
+++ b/disteval/visualization/comparison_plotter/functions/plot_funcs.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import numpy as np
 from matplotlib import pyplot as plt
-import matplotlib.patches as mpatches
 from matplotlib.colors import ColorConverter
 import matplotlib.transforms as transforms
 from colorsys import rgb_to_hls, hls_to_rgb

--- a/disteval/visualization/comparison_plotter/functions/plot_funcs.py
+++ b/disteval/visualization/comparison_plotter/functions/plot_funcs.py
@@ -4,6 +4,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 import matplotlib.patches as mpatches
 from matplotlib.colors import ColorConverter
+import matplotlib.transforms as transforms
 from colorsys import rgb_to_hls, hls_to_rgb
 
 from .calc_funcs import map_aggarwal_ratio, rescale_limit
@@ -34,37 +35,39 @@ def plot_inf_marker(fig,
                     markeredgecolor='k',
                     markerfacecolor='none',
                     bot=True,
-                    alpha=1.):
-    patches = []
-    radius = 0.005
+                    alpha=1.,
+                    rel_marker_size=0.009):
+
+    # compute marker size
+    pixel_width, pixel_height = fig.canvas.get_width_height()
+    markersize = pixel_height * rel_marker_size
+
+    # get coordinate transformation
+    trans = transforms.blended_transform_factory(
+              ax.transData, fig.transFigure)
+
     bbox = ax.get_position()
-    x_0 = bbox.x0
-    width = bbox.x1 - bbox.x0
     if bot:
-        y0 = bbox.y0 + radius
-        orientation = np.pi
+        y0 = bbox.y0 + rel_marker_size
+        marker = 'v'
     else:
-        y0 = bbox.y1 - radius
-        orientation = 0
+        y0 = bbox.y1 - rel_marker_size
+        marker = '^'
+
     bin_center = (binning[1:] + binning[:-1]) / 2
-    binning_width = binning[-1] - binning[0]
-    bin_0 = binning[0]
+
     for bin_i, place in zip(bin_center, place_marker):
         if place:
-            x_i = ((bin_i - bin_0) / binning_width * width) + x_0
-            patches.append(mpatches.RegularPolygon(
-                [x_i, y0],
-                3,
-                radius=radius,
-                orientation=orientation,
-                facecolor=markerfacecolor,
-                edgecolor=markeredgecolor,
-                transform=fig.transFigure,
-                figure=fig,
-                linewidth=1.,
-                zorder=MAIN_ZORDER + 1,
-                alpha=alpha))
-    fig.patches.extend(patches)
+            ax.plot([bin_i, ], [y0, ],
+                    transform=trans,
+                    marker=marker,
+                    markerfacecolor=markerfacecolor,
+                    markeredgecolor=markeredgecolor,
+                    markersize=markersize,
+                    figure=fig,
+                    linewidth=1.,
+                    zorder=MAIN_ZORDER + 1,
+                    alpha=alpha)
 
 
 def plot_finite_marker(ax, x, y, facecolor, edgecolor, alpha):


### PR DESCRIPTION
The previous implementation assumed that the x-scale would not change. Hence, the positions of the infinite markers were in the wrong place when the x-axis scale was changed. The x-coordinate of the marker is now provided in data-coordinates rather than figure-coordinates. Due to x and y being defined in different coordinate systems, the implementation via RegularPolygon breaks which assumes x and y to be in the same coordinate system. A regular marker is used now instead. 

As a result, the shape of the marker changes slightly from the previous implementation. 
Is this a problem?

Matplotlib markers 6 (CARETUP) and 7 (CARETDOWN) or 10 (CARETUPBASE) and 11 (CARETDOWNBASE) probably resemble the previous marker better. However, I ran into issues with the edgecolors, where it would not draw all edges.

This implementation can be further improved to center the marker in log-space bins rather than lin-space bins.




